### PR TITLE
Fixed bug that prevented false values from being correctly parsed when set with default value

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ VARIABE=VALUE. You can use the provived .env-example as a template.
    * @returns {string | any | *}
    */
   withDefault: (environmentVariable, defaultValue) => {
-    return self.returnValue(process.env[environmentVariable]) || defaultValue
+    return process.env[environmentVariable] ? self.returnValue(process.env[environmentVariable]):defaultValue
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -63,3 +63,8 @@ test('Should return string true from string provided', () => {
   process.env.UNITTESTVALUE = "'true'"
   expect(index.required('UNITTESTVALUE')).toBe('true')
 })
+
+test('should return `false` when specified env is set to false against the specified default value', () => {
+  process.env.UNITTESTVALUE = 'false',
+  expect(index.withDefault('UNITTESTVALUE', true)).toEqual(false);
+})


### PR DESCRIPTION
Fixed a bug where false values were ignored when set against default value.

For example if the env value is `VERBOSE=false` and the config is set up as follows:

```typescript
{
  verbose: ConfigHelper.withDefault('VERBOSE', true)  
}
```
Previously, `verbose` will always be `true`, ignoring the value set in the `env`.